### PR TITLE
Adds CVA, polymorphic, and new Button component

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-toast": "^1.1.4",
     "@tanstack/react-query": "^4.29.7",
     "ansi-html-community": "^0.0.8",
+    "class-variance-authority": "^0.6.1",
     "classnames": "^2.3.2",
     "date-fns": "^2.30.0",
     "js-base64": "^3.7.5",

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import type {
+  PolymorphicForwardRefExoticComponent,
+  PolymorphicPropsWithoutRef,
+  PolymorphicPropsWithRef,
+} from "../../library/polymorphic";
+import type { VariantProps } from "class-variance-authority";
+import { buttonVariants } from "./variants";
+
+export interface ButtonProps extends VariantProps<typeof buttonVariants> {}
+
+export type ForwardedButtonProps<T extends React.ElementType = "button"> =
+  PolymorphicPropsWithRef<ButtonProps, T>;
+
+export const Button: PolymorphicForwardRefExoticComponent<
+  ButtonProps,
+  "button"
+> = React.forwardRef(function Heading<T extends React.ElementType = "button">(
+  {
+    as,
+    intent,
+
+    className,
+    ...restProps
+  }: PolymorphicPropsWithoutRef<ButtonProps, T>,
+  ref: React.ForwardedRef<Element>
+) {
+  const Element: React.ElementType = as || "button";
+  return (
+    <Element
+      ref={ref}
+      className={buttonVariants({ intent, className })}
+      {...restProps}
+    />
+  );
+});

--- a/src/components/button/variants.ts
+++ b/src/components/button/variants.ts
@@ -1,0 +1,82 @@
+import { cva } from "class-variance-authority";
+
+/**
+ * Button variants.
+ *
+ * Enables a repeatable structure to relate class names to component props.
+ *
+ * @example
+ * <Button intent="primary">Build now</Button
+ *
+ * @see https://cva.style/docs
+ */
+export const buttonVariants = cva(
+  [
+    "inline-block",
+    "w-auto",
+    "leading-6",
+    "max-w-full",
+    "cursor-pointer",
+    "text-center",
+    "font-bold",
+    "select-none",
+    "whitespace-nowrap",
+    "border-2",
+    "border-transparent",
+    "no-underline",
+    "sm:px-[1.2rem]",
+    "sm:py-[0.4rem]",
+    "px-[1rem]",
+    "py-[0.2rem]",
+  ],
+  {
+    variants: {
+      intent: {
+        primary: [
+          "bg-vela-cyan",
+          "hover:border-vela-cyan",
+          "text-vela-coal",
+          "hover:bg-vela-coal",
+          "hover:text-vela-offwhite",
+          "focus:border-vela-cyan",
+          "focus:bg-vela-coal",
+          "focus:text-vela-offwhite",
+
+          "disabled:cursor-not-allowed",
+          "disabled:bg-vela-cyan/75",
+          "disabled:hover:text-vela-coal",
+          "disabled:hover:border-transparent",
+        ],
+        secondary: [
+          "border-vela-cyan",
+          "bg-vela-coal",
+          "text-vela-cyan",
+          "hover:border-vela-cyan",
+          "hover:bg-vela-cyan",
+          "hover:text-vela-coal",
+          "focus:border-vela-cyan",
+          "focus:bg-vela-cyan",
+          "focus:text-vela-coal",
+
+          "disabled:cursor-not-allowed",
+          "disabled:hover:bg-vela-coal",
+          "disabled:text-vela-cyan/50",
+        ],
+        underlined: [
+          "bg-vela-coal",
+          "border-b-vela-coal-light",
+          "text-vela-gray",
+          "hover:text-vela-white",
+
+          "disabled:cursor-not-allowed",
+          "disabled:border-b-vela-coal-light/50",
+          "disabled:text-vela-white/50",
+        ],
+      },
+    },
+    compoundVariants: [],
+    defaultVariants: {
+      intent: "primary",
+    },
+  }
+);

--- a/src/library/polymorphic.ts
+++ b/src/library/polymorphic.ts
@@ -1,0 +1,69 @@
+import React from "react";
+
+/**
+ * Polymorphic types. Borrowed from MIT licensed `react-polymorphic-types`.
+ *
+ * Without carrying its own runtime weight, this collection of types enables `as` props.
+ *
+ * @see https://www.npmjs.com/package/react-polymorphic-types
+ */
+export {};
+
+type Merge<T, U> = Omit<T, keyof U> & U;
+
+type PropsWithAs<P, T extends React.ElementType> = P & { as?: T };
+
+export type PolymorphicPropsWithoutRef<P, T extends React.ElementType> = Merge<
+  T extends keyof JSX.IntrinsicElements
+    ? React.PropsWithoutRef<JSX.IntrinsicElements[T]>
+    : React.ComponentPropsWithoutRef<T>,
+  PropsWithAs<P, T>
+>;
+
+export type PolymorphicPropsWithRef<P, T extends React.ElementType> = Merge<
+  T extends keyof JSX.IntrinsicElements
+    ? React.PropsWithRef<JSX.IntrinsicElements[T]>
+    : React.ComponentPropsWithRef<T>,
+  PropsWithAs<P, T>
+>;
+
+type PolymorphicExoticComponent<
+  P = unknown,
+  T extends React.ElementType = React.ElementType
+> = Merge<
+  React.ExoticComponent<P & { [key: string]: unknown }>,
+  {
+    /**
+     * **NOTE**: Exotic components are not callable.
+     */
+    <InstanceT extends React.ElementType = T>(
+      props: PolymorphicPropsWithRef<P, InstanceT>
+    ): React.ReactElement | null;
+  }
+>;
+
+export type PolymorphicForwardRefExoticComponent<
+  P,
+  T extends React.ElementType
+> = Merge<
+  React.ForwardRefExoticComponent<P & { [key: string]: unknown }>,
+  PolymorphicExoticComponent<P, T>
+>;
+
+export type PolymorphicMemoExoticComponent<
+  P,
+  T extends React.ElementType
+> = Merge<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  React.MemoExoticComponent<React.ComponentType<any>>,
+  PolymorphicExoticComponent<P, T>
+>;
+
+export type PolymorphicLazyExoticComponent<
+  P,
+  T extends React.ElementType
+> = Merge<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  React.LazyExoticComponent<React.ComponentType<any>>,
+  PolymorphicExoticComponent<P, T>
+>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,6 +993,13 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
+class-variance-authority@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/class-variance-authority/-/class-variance-authority-0.6.1.tgz#9482856c1496d33c21ef19e65b5d255460aa8039"
+  integrity sha512-eurOEGc7YVx3majOrOb099PNKgO3KnKSApOprXI4BTq6bcfbqbQXPN2u+rPPmIJ2di23bMwhk0SxCCthBmszEQ==
+  dependencies:
+    clsx "1.2.1"
+
 classnames@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
@@ -1002,6 +1009,11 @@ client-only@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
+
+clsx@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
 color-convert@^1.9.0:
   version "1.9.3"


### PR DESCRIPTION
Using class variance authority, a set of polymorphic types I copied (MIT, credited) into the codebase that enables reliable typing for `as` props, and the new product of all that, an actual Button component instead of just `className="btn-primary"`.