### PR TITLE
Feature paginaton bodge

### DIFF
--- a/src/api/core/request.ts
+++ b/src/api/core/request.ts
@@ -335,7 +335,20 @@ export const request = <T>(
 
         catchErrorCodes(options, result);
 
-        resolve(result.body);
+        /**
+         * TODO / NOTE: How would we official expose access to headers?
+         * This is a _trick_ that secretly mutates a portion of an object and sets the headers.
+         *
+         * See the src/library/headers.ts file for examples of access.
+         */
+
+        if (responseBody && typeof responseBody === "object") {
+          responseBody.__headers = Object.fromEntries(
+            response.headers.entries()
+          );
+        }
+
+        resolve(responseBody);
       }
     } catch (error) {
       reject(error);

--- a/src/components/Pager2.tsx
+++ b/src/components/Pager2.tsx
@@ -1,0 +1,51 @@
+import { useNavigate } from "react-router";
+import { SerializedHeaders } from "../library/headers";
+
+interface PagerProps {
+  page: number;
+  path: string;
+  pagination: SerializedHeaders | null;
+}
+
+// todo: the api returns Link information for paging
+// but we have no access to it using the api interface package
+// <https://vela.example.com/api/v1/repos/example_org?per_page=10&page=1>; rel="first", <https://vela.example.com/api/v1/repos/example_org?per_page=10&page=49>; rel="last", <https://vela.example.com/api/v1/repos/example_org?per_page=10&page=49>; rel="next", <https://vela.example.com/api/v1/repos/example_org?per_page=10&page=47>; rel="prev"
+export function Pager2(props: PagerProps) {
+  const newer = Math.max(props.page - 1, 1);
+  const older = props.page + 1;
+
+  const navigate = useNavigate();
+
+  function handlePage(dir: -1 | 1) {
+    const page = dir === -1 ? newer : older;
+    const dest = {
+      pathname: props.path,
+      search: `page=${page}`,
+    };
+    navigate(dest);
+  }
+
+  const left = props.pagination && "prev" in props.pagination;
+  const right = props.pagination && "next" in props.pagination;
+
+  console.log("details=", props.pagination);
+
+  // these could have been Link but
+  // I wanted to maintain any existing query strings in the url
+  // if they were in there but neither way in
+  // react router seem to make it easy
+  return (
+    <div className="flex justify-end gap-4">
+      {left && (
+        <button className="btn-secondary" onClick={() => handlePage(-1)}>
+          ← newer
+        </button>
+      )}
+      {right && (
+        <button className="btn-secondary" onClick={() => handlePage(1)}>
+          older →
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/library/headers.ts
+++ b/src/library/headers.ts
@@ -1,0 +1,65 @@
+/**
+ * What is all of this?
+ *
+ * It's a workaround for the API using headers to define pagination and total count status.
+ *
+ * We dangerously append a secret field `__headers` to api body results returned.
+ *
+ * Then, we can get access back to those headers using these methods.
+ *
+ * We need to adjust the Generated API if we do not want this approach, or convert the responses
+ * to inline pagination details.
+ */
+
+export type SerializedHeaders = Record<string, string>;
+
+export function getHeaders(value: unknown): SerializedHeaders | null {
+  if (value && typeof value === "object" && "__headers" in value) {
+    return value.__headers as SerializedHeaders;
+  }
+
+  return null;
+}
+
+export function getTotalCount(headers: SerializedHeaders | null) {
+  const name = "x-total-count";
+
+  if (!headers) {
+    return null;
+  }
+
+  const header = headers[name];
+  return header ?? null;
+}
+
+export function getLink(headers: SerializedHeaders | null) {
+  const name = "link";
+
+  if (!headers) {
+    return null;
+  }
+
+  const header = headers[name];
+  return header ?? null;
+}
+
+export function getPagination(header: string | null) {
+  if (!header) {
+    return null;
+  }
+
+  const tuples = header.split(",").map((s) => s.trim());
+  const kvs = tuples.map((tuple) => {
+    const matches = [...tuple.matchAll(/<(.*)>;\srel="(.*)"/gi)];
+
+    const key = matches[0][2];
+    const value = matches[0][1];
+    const kv = [key, value];
+
+    return kv;
+  });
+
+  const serializedHeaders: SerializedHeaders = Object.fromEntries(kvs);
+
+  return serializedHeaders;
+}

--- a/src/pages/RepoBuilds.tsx
+++ b/src/pages/RepoBuilds.tsx
@@ -6,6 +6,8 @@ import { useBuildsQuery } from "../library/hooks/useBuilds";
 import { useOrgRepoParams } from "../library/hooks/useOrgRepoParams";
 import { usePageParam } from "../library/hooks/usePageParam";
 import { TopBumper } from "../components/TopBumper";
+import { getHeaders, getLink, getPagination } from "../library/headers";
+import { Pager2 } from "../components/Pager2";
 
 export function RepoBuilds() {
   const { org, repo } = useOrgRepoParams();
@@ -13,6 +15,8 @@ export function RepoBuilds() {
 
   const { builds } = useBuildsQuery(org!, repo!, page);
   // todo: sorting/filtering
+
+  const pagination = getPagination(getLink(getHeaders(builds.data)));
 
   return (
     <>
@@ -30,7 +34,11 @@ export function RepoBuilds() {
               </div>
               {builds.isSuccess && builds.data.length > 0 ? (
                 <div>
-                  <Pager path={`/${org}/${repo}`} page={page} />
+                  <Pager2
+                    path={`/${org}/${repo}`}
+                    page={page}
+                    pagination={pagination}
+                  />
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
Pagination needs Generated API support. The Vela API puts `Link` headers into the response during pagination requests/responses. The Generated API abstracts out the HTTP layer, so there's no access to status code or response headers once the request has resolved into a response.

- We could change that manually, to include header data as an object `{body, headers}`
- That's an issue if we re-generate the Generated API

So for now, this is a _bodge_, we dangerously attach a `__headers` and then access that safely though checks. The power of duck typing here is useful.

In the UI side of things, this is mostly an example. When the #1 gets merged, we can use the new `disabled` states that PR introduces for buttons so that we don't have the page jumping around.

<img width="807" alt="Screenshot 2023-07-09 at 9 32 03 PM" src="https://github.com/zapplebee/ui-hackathon/assets/13507/0a027ad1-17d2-4f34-8a92-8ec25ee299b1">
<img width="814" alt="Screenshot 2023-07-09 at 9 32 10 PM" src="https://github.com/zapplebee/ui-hackathon/assets/13507/8cb4ae02-a318-4c96-97a1-618956b55afa">
<img width="809" alt="Screenshot 2023-07-09 at 9 32 17 PM" src="https://github.com/zapplebee/ui-hackathon/assets/13507/f452752a-2ed3-4a0f-a59f-4381afb7dd28">

I haven't thought about the usability implications of this yet, but with this new pagination info accessible, we could have additional buttons for newest, oldest.

![image](https://github.com/zapplebee/ui-hackathon/assets/13507/010208c8-5fd9-4146-abd3-cf0c6a926c88)
