### PR TITLE
Feature invariants

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-helmet-async": "^1.3.0",
     "react-hook-form": "^7.45.1",
     "react-router": "^6.11.2",
-    "react-router-dom": "^6.11.2"
+    "react-router-dom": "^6.11.2",
+    "tiny-invariant": "^1.3.1"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.3",

--- a/src/library/hooks/useOrgParam.ts
+++ b/src/library/hooks/useOrgParam.ts
@@ -1,0 +1,16 @@
+import { useParams } from "react-router";
+import invariant from "tiny-invariant";
+
+export function useOrgParam() {
+  const { org } = useParams();
+
+  if (!org) {
+    if ("production" !== process.env.NODE_ENV) {
+      invariant(false, "org param missing");
+    } else {
+      invariant(false);
+    }
+  }
+
+  return org;
+}

--- a/src/library/hooks/useOrgParam.ts
+++ b/src/library/hooks/useOrgParam.ts
@@ -4,13 +4,7 @@ import invariant from "tiny-invariant";
 export function useOrgParam() {
   const { org } = useParams();
 
-  if (!org) {
-    if ("production" !== process.env.NODE_ENV) {
-      invariant(false, "org param missing");
-    } else {
-      invariant(false);
-    }
-  }
+  invariant(!!org, "org param missing");
 
   return org;
 }

--- a/src/library/hooks/useOrgRepoParams.ts
+++ b/src/library/hooks/useOrgRepoParams.ts
@@ -1,5 +1,12 @@
 import { useParams } from "react-router";
 
+/**
+ * Gets the org and repo route params.
+ *
+ * @deprecated use useOrgParam and useRepoParam instead
+ *
+ * @returns an object with org and repo
+ */
 export function useOrgRepoParams() {
   const params = useParams();
 

--- a/src/library/hooks/useRepoParam.ts
+++ b/src/library/hooks/useRepoParam.ts
@@ -1,0 +1,16 @@
+import { useParams } from "react-router";
+import invariant from "tiny-invariant";
+
+export function useRepoParam() {
+  const { repo } = useParams();
+
+  if (!repo) {
+    if ("production" !== process.env.NODE_ENV) {
+      invariant(false, "repo param missing");
+    } else {
+      invariant(false);
+    }
+  }
+
+  return repo;
+}

--- a/src/library/hooks/useRepoParam.ts
+++ b/src/library/hooks/useRepoParam.ts
@@ -4,13 +4,7 @@ import invariant from "tiny-invariant";
 export function useRepoParam() {
   const { repo } = useParams();
 
-  if (!repo) {
-    if ("production" !== process.env.NODE_ENV) {
-      invariant(false, "repo param missing");
-    } else {
-      invariant(false);
-    }
-  }
+  invariant(!!repo, "repo param missing");
 
   return repo;
 }

--- a/src/pages/RepoBuilds.tsx
+++ b/src/pages/RepoBuilds.tsx
@@ -2,16 +2,19 @@ import React from "react";
 import { BuildRow } from "../components/BuildRow";
 import { Loader } from "../components/Loader";
 import { Pager } from "../components/Pager";
-import { useBuildsQuery } from "../library/hooks/useBuilds";
-import { useOrgRepoParams } from "../library/hooks/useOrgRepoParams";
-import { usePageParam } from "../library/hooks/usePageParam";
 import { TopBumper } from "../components/TopBumper";
+import { useBuildsQuery } from "../library/hooks/useBuilds";
+import { useOrgParam } from "../library/hooks/useOrgParam";
+import { usePageParam } from "../library/hooks/usePageParam";
+import { useRepoParam } from "../library/hooks/useRepoParam";
 
 export function RepoBuilds() {
-  const { org, repo } = useOrgRepoParams();
+  const org = useOrgParam();
+  const repo = useRepoParam();
+
   const { page } = usePageParam();
 
-  const { builds } = useBuildsQuery(org!, repo!, page);
+  const { builds } = useBuildsQuery(org, repo, page);
   // todo: sorting/filtering
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2135,6 +2135,11 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+tiny-invariant@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
+  integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"


### PR DESCRIPTION
In this PR, I am experimenting with tiny-invariant.

https://www.npmjs.com/package/tiny-invariant

With this, I can narrow the `useParams` return type `<string | undefined>` to just `<string>`.

The question is, is it worth...

1. keeping the bundle weight of the messages
2. the noise this bundle dead code elimination requires
3. not having the messages in prod if it did somehow happen?